### PR TITLE
Add .gitignore file to exclude unnecessary files from the repository  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,68 @@
+# Compiled class files  
+*.class  
+  
+# Log files  
+*.log  
+  
+# BlueJ files  
+*.ctxt  
+  
+# Mobile Tools for Java (J2ME)  
+.mtj.tmp/  
+  
+# Package Files #  
+*.jar  
+*.war  
+*.ear  
+  
+# Virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml  
+hs_err_pid*  
+  
+# Maven  
+target/  
+pom.xml.tag  
+pom.xml.releaseBackup  
+pom.xml.versionsBackup  
+pom.xml.next  
+release.properties  
+  
+# Gradle  
+.gradle  
+build/  
+  
+# IntelliJ IDEA  
+.idea/  
+*.iws  
+*.iml  
+*.ipr  
+  
+# Eclipse  
+.metadata  
+*.tmp  
+*.bak  
+*.swp  
+*~.nib  
+.localhistory  
+  
+# NetBeans  
+nbproject/private/  
+build/  
+nbbuild/  
+dist/  
+nbdist/  
+.nb-gradle/  
+  
+# VS Code  
+.vscode/  
+  
+# OS-specific files  
+.DS_Store  
+Thumbs.db  
+  
+# Spring Boot specific  
+spring-boot-*.jar  
+spring-boot-*.war  
+spring-boot-devtools-*.jar  
+  
+# Git  
+.git/ 


### PR DESCRIPTION
## What  
This pull request adds a `.gitignore` file to the repository.  
  
## Why  
The `.gitignore` file is necessary to exclude files that are not needed in the repository. These files include:  
- Compiled class files (`*.class`)  
- Log files (`*.log`)  
- IDE-specific files (e.g., IntelliJ IDEA, Eclipse)  
- Build directories (`target/`, `build/`)  
- OS-specific files (`.DS_Store`, `Thumbs.db`)  
- Temporary files and other unnecessary files  
  
## How  
The `.gitignore` file was created with entries to exclude common unnecessary files for a Java (Spring Boot) project. This will help keep the repository clean and focused on the source code and essential configuration files.  
  
## Impact  
This change does not affect any existing functionality. It only helps in maintaining a clean repository by ignoring unnecessary files.  
